### PR TITLE
docs(readme): Update the reference after example moved

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,6 @@ documentation to learn more.
 
 ## Example
 
-You can find a complete example setup with Grafana Tempo in the [Pyroscope repository](https://github.com/grafana/pyroscope/tree/main/examples/tracing/tempo).
+You can find a complete example setup with Grafana Tempo in the [Pyroscope repository](https://github.com/grafana/pyroscope/tree/main/examples/tracing/golang-push).
 
 ![image](https://github.com/grafana/otel-profiling-go/assets/12090599/31e33cd1-818b-4116-b952-c9ec7b1fb593)


### PR DESCRIPTION
We moved this around, so go has its own example for tracing