### PR TITLE
Added functional option to attach trace_id label to profiles

### DIFF
--- a/otelpyroscope.go
+++ b/otelpyroscope.go
@@ -12,6 +12,7 @@ import (
 const (
 	spanIDLabelName   = "span_id"
 	spanNameLabelName = "span_name"
+	traceIDLabelName  = "trace_id"
 )
 
 var profileIDSpanAttributeKey = attribute.Key("pyroscope.profile.id")
@@ -24,8 +25,9 @@ type tracerProvider struct {
 }
 
 type config struct {
-	spanNameScope scope
-	spanIDScope   scope
+	spanNameScope   scope
+	spanIDScope     scope
+	addTraceIDLabel bool
 }
 
 type Option func(*tracerProvider)
@@ -62,11 +64,13 @@ func (w *profileTracer) Start(ctx context.Context, spanName string, opts ...trac
 	spanCtx := span.SpanContext()
 	addSpanIDLabel := w.p.config.spanIDScope != scopeNone && spanCtx.IsSampled()
 	addSpanNameLabel := w.p.config.spanNameScope != scopeNone && spanName != ""
-	if !(addSpanIDLabel || addSpanNameLabel) {
+	addTraceIDLabel := w.p.config.addTraceIDLabel && spanCtx.TraceID().IsValid()
+	if !(addSpanIDLabel || addSpanNameLabel || addTraceIDLabel) {
 		return ctx, span
 	}
 
 	spanID := spanCtx.SpanID().String()
+	traceID := spanCtx.TraceID().String()
 	s := spanWrapper{
 		Span: span,
 		ctx:  ctx,
@@ -76,8 +80,9 @@ func (w *profileTracer) Start(ctx context.Context, spanName string, opts ...trac
 	rs, ok := rootSpanFromContext(ctx)
 	if !ok {
 		// This is the first local span.
-		rs.id = spanID
-		rs.name = spanName
+		rs.spanID = spanID
+		rs.spanName = spanName
+		rs.traceID = traceID
 		ctx = withRootSpan(ctx, rs)
 	}
 
@@ -85,22 +90,28 @@ func (w *profileTracer) Start(ctx context.Context, spanName string, opts ...trac
 	// only if they _can_ have profiles. Presence of the attribute
 	// does not indicate the fact that we actually have collected
 	// any samples for the span.
-	if (w.p.config.spanIDScope == scopeRootSpan && spanID == rs.id) ||
+	if (w.p.config.spanIDScope == scopeRootSpan && spanID == rs.spanID) ||
 		w.p.config.spanIDScope == scopeAllSpans {
 		span.SetAttributes(profileIDSpanAttributeKey.String(spanID))
 	}
-	labels := make([]string, 0, 4)
+	labels := make([]string, 0, 6)
 	if addSpanNameLabel {
 		if w.p.config.spanNameScope == scopeRootSpan {
-			spanName = rs.name
+			spanName = rs.spanName
 		}
 		labels = append(labels, spanNameLabelName, spanName)
 	}
 	if addSpanIDLabel {
 		if w.p.config.spanIDScope == scopeRootSpan {
-			spanID = rs.id
+			spanID = rs.spanID
 		}
 		labels = append(labels, spanIDLabelName, spanID)
+	}
+	if addTraceIDLabel {
+		if rs.traceID != "" {
+			traceID = rs.traceID
+		}
+		labels = append(labels, traceIDLabelName, traceID)
 	}
 
 	ctx = pprof.WithLabels(ctx, pprof.Labels(labels...))
@@ -122,8 +133,9 @@ func (s spanWrapper) End(options ...trace.SpanEndOption) {
 type rootSpanCtxKey struct{}
 
 type rootSpan struct {
-	id   string
-	name string
+	spanID   string
+	spanName string
+	traceID  string
 }
 
 func withRootSpan(ctx context.Context, s rootSpan) context.Context {
@@ -133,6 +145,14 @@ func withRootSpan(ctx context.Context, s rootSpan) context.Context {
 func rootSpanFromContext(ctx context.Context) (rootSpan, bool) {
 	s, ok := ctx.Value(rootSpanCtxKey{}).(rootSpan)
 	return s, ok
+}
+
+// WithTraceID specifies that the span trace ID should be added to the profile
+// labels when available.
+func WithTraceID() Option {
+	return func(tp *tracerProvider) {
+		tp.config.addTraceIDLabel = true
+	}
 }
 
 // TODO(kolesnikovae): Make options public.

--- a/otelpyroscope_test.go
+++ b/otelpyroscope_test.go
@@ -67,3 +67,83 @@ func Test_tracerProvider(t *testing.T) {
 	})
 	spanC.End()
 }
+
+func Test_tracerProvider_WithTraceID(t *testing.T) {
+	otel.SetTracerProvider(NewTracerProvider(trace.NewTracerProvider(), WithTraceID()))
+
+	tracer := otel.Tracer("")
+	labels := make(map[string]string)
+
+	ctx, spanR := tracer.Start(context.Background(), "RootSpan")
+	pprof.ForLabels(ctx, func(key, value string) bool {
+		labels[key] = value
+		return true
+	})
+
+	// Verify span_id is present
+	spanID, ok := labels[spanIDLabelName]
+	if !ok {
+		t.Fatal("span ID label not found")
+	}
+	if len(spanID) != 16 {
+		t.Fatalf("invalid span ID: %q", spanID)
+	}
+
+	// Verify span_name is present
+	name, ok := labels[spanNameLabelName]
+	if !ok {
+		t.Fatal("span name label not found")
+	}
+	if name != "RootSpan" {
+		t.Fatalf("invalid span name: %q", name)
+	}
+
+	// Verify trace_id is present
+	traceID, ok := labels[traceIDLabelName]
+	if !ok {
+		t.Fatal("trace ID label not found")
+	}
+	if len(traceID) != 32 {
+		t.Fatalf("invalid trace ID length: expected 32, got %d for %q", len(traceID), traceID)
+	}
+
+	// Nested child span should have the same trace_id
+	ctx, spanA := tracer.Start(ctx, "SpanA")
+	childLabels := make(map[string]string)
+	pprof.ForLabels(ctx, func(key, value string) bool {
+		childLabels[key] = value
+		return true
+	})
+
+	childTraceID, ok := childLabels[traceIDLabelName]
+	if !ok {
+		t.Fatal("trace ID label not found in child span")
+	}
+	if childTraceID != traceID {
+		t.Fatalf("child span trace ID mismatch: expected %q, got %q", traceID, childTraceID)
+	}
+
+	spanA.End()
+	spanR.End()
+
+	// A new root span should have a different trace_id
+	ctx, spanB := tracer.Start(context.Background(), "SpanB")
+	newLabels := make(map[string]string)
+	pprof.ForLabels(ctx, func(key, value string) bool {
+		newLabels[key] = value
+		return true
+	})
+
+	newTraceID, ok := newLabels[traceIDLabelName]
+	if !ok {
+		t.Fatal("trace ID label not found in new root span")
+	}
+	if newTraceID == traceID {
+		t.Fatalf("new root span should have different trace ID, but got same: %q", newTraceID)
+	}
+	if len(newTraceID) != 32 {
+		t.Fatalf("invalid trace ID length: expected 32, got %d for %q", len(newTraceID), newTraceID)
+	}
+
+	spanB.End()
+}


### PR DESCRIPTION
This PR adds a functional option that when set causes `trace_id` label to be attached to profiles.

Example usage:

```go
otel.SetTracerProvider(otelpyroscope.NewTracerProvider(tp, otelpyroscope.WithTraceID()))
```


<img width="424" height="249" alt="Screenshot 1" src="https://github.com/user-attachments/assets/ec3e63b8-768d-43cf-a57d-4ea5230d8ebc" />

This provides the capability to jump from profiles to traces by copying the `trace_id` and looking it up:

<img width="1704" height="965" alt="Screenshot 2" src="https://github.com/user-attachments/assets/ebb310b6-d1b3-44b1-9cea-570a858998d2" />


