### PR TITLE
feat: add trace_id pprof label

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Limitations:
 
 ## Options
 
-- `WithTraceIDLabel(bool)` — enable/disable the `trace_id` pprof label. Default `true`.
 - `WithSpanIDLabelScope(Scope)` — control whether the `span_id` label is emitted: `ScopeNone` (off),
   `ScopeRootSpan` (default — local root only, descendants inherit the root's value), or `ScopeAllSpans`
   (every span emits its own). `ScopeAllSpans` significantly increases label cardinality.

--- a/README.md
+++ b/README.md
@@ -1,19 +1,30 @@
 # Profiling Instrumentation for OpenTelemetry Go SDK
 
-The package provides means to integrate tracing with profiling. More specifically, a `TracerProvider` implementation,
-that annotates profiling data with span IDs: when a new trace span emerges, the tracer adds a `span_id` [pprof tag](https://github.com/google/pprof/blob/master/doc/README.md#tag-filtering)
-that points to the span. This makes it possible to filter out a profile of a particular trace span in [Pyroscope](https://pyroscope.io).
+The package provides means to integrate tracing with profiling. More specifically, a `TracerProvider` implementation
+that annotates profiling data with `trace_id` and `span_id` [pprof tags](https://github.com/google/pprof/blob/master/doc/README.md#tag-filtering),
+making it possible to filter the profile of a particular trace or span in [Pyroscope](https://grafana.com/docs/pyroscope/latest/).
 
 Note that the module does not control `pprof` profiler itself – it still needs to be started for profiles to be
 collected. This can be done either via `runtime/pprof` package, or using the [Pyroscope client](https://github.com/grafana/pyroscope-go).
 
-By default, only the root span gets labeled (the first span created locally): such spans are marked with the
-`pyroscope.profile.id` attribute set to the span ID. Please note that presence of the attribute does not necessarily
-indicate that the span has a profile: stack trace samples might not be collected, if the utilized CPU time is
-less than the sample interval (10ms).
+By default:
+- The `trace_id` label is added on the local root span and inherited by every descendant span through pprof's context
+  label propagation.
+- The `span_id` label and `pyroscope.profile.id` span attribute are set on the local root span only (the first span
+  created locally) — this is the join key Grafana's "Traces to profiles" UI uses today. Presence of the attribute
+  does not necessarily indicate that the span has a profile: stack trace samples might not be collected if the
+  utilized CPU time is less than the sample interval (10ms).
 
 Limitations:
 - Only CPU profiling is fully supported at the moment.
+
+## Options
+
+- `WithTraceIDLabel(bool)` — enable/disable the `trace_id` pprof label. Default `true`.
+- `WithSpanIDLabelScope(Scope)` — control whether the `span_id` label is emitted: `ScopeNone` (off),
+  `ScopeRootSpan` (default — local root only, descendants inherit the root's value), or `ScopeAllSpans`
+  (every span emits its own). `ScopeAllSpans` significantly increases label cardinality.
+- `WithSpanNameLabelScope(Scope)` — same, for the `span_name` label.
 
 ### Trace spans profiles
 

--- a/otelpyroscope.go
+++ b/otelpyroscope.go
@@ -12,6 +12,7 @@ import (
 const (
 	spanIDLabelName   = "span_id"
 	spanNameLabelName = "span_name"
+	traceIDLabelName  = "trace_id"
 )
 
 var profileIDSpanAttributeKey = attribute.Key("pyroscope.profile.id")
@@ -24,21 +25,22 @@ type tracerProvider struct {
 }
 
 type config struct {
-	spanNameScope scope
-	spanIDScope   scope
+	spanNameScope  Scope
+	spanIDScope    Scope
+	traceIDEnabled bool
 }
 
 type Option func(*tracerProvider)
 
-// NewTracerProvider creates a new tracer provider that annotates pprof
-// samples with span_id label. This allows to establish a relationship
-// between pprof profiles and reported tracing spans.
+// NewTracerProvider returns a TracerProvider that annotates pprof samples
+// with span_id and trace_id labels for trace↔profile correlation.
 func NewTracerProvider(tp trace.TracerProvider, options ...Option) trace.TracerProvider {
 	p := tracerProvider{
 		tp: tp,
 		config: config{
-			spanNameScope: scopeRootSpan,
-			spanIDScope:   scopeRootSpan,
+			spanNameScope:  ScopeRootSpan,
+			spanIDScope:    ScopeRootSpan,
+			traceIDEnabled: true,
 		},
 	}
 	for _, o := range options {
@@ -60,9 +62,10 @@ type profileTracer struct {
 func (w *profileTracer) Start(ctx context.Context, spanName string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
 	ctx, span := w.tr.Start(ctx, spanName, opts...)
 	spanCtx := span.SpanContext()
-	addSpanIDLabel := w.p.config.spanIDScope != scopeNone && spanCtx.IsSampled()
-	addSpanNameLabel := w.p.config.spanNameScope != scopeNone && spanName != ""
-	if !(addSpanIDLabel || addSpanNameLabel) {
+	addSpanIDLabel := w.p.config.spanIDScope != ScopeNone && spanCtx.IsSampled()
+	addSpanNameLabel := w.p.config.spanNameScope != ScopeNone && spanName != ""
+	addTraceIDLabel := w.p.config.traceIDEnabled && spanCtx.IsSampled()
+	if !(addSpanIDLabel || addSpanNameLabel || addTraceIDLabel) {
 		return ctx, span
 	}
 
@@ -74,7 +77,8 @@ func (w *profileTracer) Start(ctx context.Context, spanName string, opts ...trac
 	}
 
 	rs, ok := rootSpanFromContext(ctx)
-	if !ok {
+	isLocalTraceEntry := !ok
+	if isLocalTraceEntry {
 		// This is the first local span.
 		rs.id = spanID
 		rs.name = spanName
@@ -85,22 +89,26 @@ func (w *profileTracer) Start(ctx context.Context, spanName string, opts ...trac
 	// only if they _can_ have profiles. Presence of the attribute
 	// does not indicate the fact that we actually have collected
 	// any samples for the span.
-	if (w.p.config.spanIDScope == scopeRootSpan && spanID == rs.id) ||
-		w.p.config.spanIDScope == scopeAllSpans {
+	if (w.p.config.spanIDScope == ScopeRootSpan && spanID == rs.id) ||
+		w.p.config.spanIDScope == ScopeAllSpans {
 		span.SetAttributes(profileIDSpanAttributeKey.String(spanID))
 	}
-	labels := make([]string, 0, 4)
+	labels := make([]string, 0, 6)
 	if addSpanNameLabel {
-		if w.p.config.spanNameScope == scopeRootSpan {
+		if w.p.config.spanNameScope == ScopeRootSpan {
 			spanName = rs.name
 		}
 		labels = append(labels, spanNameLabelName, spanName)
 	}
 	if addSpanIDLabel {
-		if w.p.config.spanIDScope == scopeRootSpan {
+		if w.p.config.spanIDScope == ScopeRootSpan {
 			spanID = rs.id
 		}
 		labels = append(labels, spanIDLabelName, spanID)
+	}
+	// Set on the local root only; descendants inherit via pprof label merge.
+	if addTraceIDLabel && isLocalTraceEntry {
+		labels = append(labels, traceIDLabelName, spanCtx.TraceID().String())
 	}
 
 	ctx = pprof.WithLabels(ctx, pprof.Labels(labels...))
@@ -135,36 +143,42 @@ func rootSpanFromContext(ctx context.Context) (rootSpan, bool) {
 	return s, ok
 }
 
-// TODO(kolesnikovae): Make options public.
+// WithTraceIDLabel controls whether the "trace_id" pprof label is emitted.
+// Defaults to true.
+func WithTraceIDLabel(enabled bool) Option {
+	return func(tp *tracerProvider) {
+		tp.config.traceIDEnabled = enabled
+	}
+}
 
-// withSpanNameLabelScope specifies whether the current span name should be
+// WithSpanNameLabelScope specifies whether the current span name should be
 // added to the profile labels. If the name is dynamic, i.e. includes
 // span-specific identifiers, such as URL or SQL query, this may significantly
 // deteriorate performance.
 //
 // By default, only the local root span name is recorded. Samples collected
 // during the child span execution will be included into the root span profile.
-func withSpanNameLabelScope(scope scope) Option {
+func WithSpanNameLabelScope(s Scope) Option {
 	return func(tp *tracerProvider) {
-		tp.config.spanNameScope = scope
+		tp.config.spanNameScope = s
 	}
 }
 
-// withSpanIDScope specifies whether the current span ID should be added to
+// WithSpanIDLabelScope specifies whether the current span ID should be added to
 // the profile labels.
 //
 // By default, only the local root span ID is recorded. Samples collected
 // during the child span execution will be included into the root span profile.
-func withSpanIDScope(scope scope) Option {
+func WithSpanIDLabelScope(s Scope) Option {
 	return func(tp *tracerProvider) {
-		tp.config.spanNameScope = scope
+		tp.config.spanIDScope = s
 	}
 }
 
-type scope uint
+type Scope uint
 
 const (
-	scopeNone = iota
-	scopeRootSpan
-	scopeAllSpans
+	ScopeNone Scope = iota
+	ScopeRootSpan
+	ScopeAllSpans
 )

--- a/otelpyroscope.go
+++ b/otelpyroscope.go
@@ -25,9 +25,8 @@ type tracerProvider struct {
 }
 
 type config struct {
-	spanNameScope  Scope
-	spanIDScope    Scope
-	traceIDEnabled bool
+	spanNameScope Scope
+	spanIDScope   Scope
 }
 
 type Option func(*tracerProvider)
@@ -38,9 +37,8 @@ func NewTracerProvider(tp trace.TracerProvider, options ...Option) trace.TracerP
 	p := tracerProvider{
 		tp: tp,
 		config: config{
-			spanNameScope:  ScopeRootSpan,
-			spanIDScope:    ScopeRootSpan,
-			traceIDEnabled: true,
+			spanNameScope: ScopeRootSpan,
+			spanIDScope:   ScopeRootSpan,
 		},
 	}
 	for _, o := range options {
@@ -64,7 +62,7 @@ func (w *profileTracer) Start(ctx context.Context, spanName string, opts ...trac
 	spanCtx := span.SpanContext()
 	addSpanIDLabel := w.p.config.spanIDScope != ScopeNone && spanCtx.IsSampled()
 	addSpanNameLabel := w.p.config.spanNameScope != ScopeNone && spanName != ""
-	addTraceIDLabel := w.p.config.traceIDEnabled && spanCtx.IsSampled()
+	addTraceIDLabel := spanCtx.IsSampled()
 	if !(addSpanIDLabel || addSpanNameLabel || addTraceIDLabel) {
 		return ctx, span
 	}
@@ -141,14 +139,6 @@ func withRootSpan(ctx context.Context, s rootSpan) context.Context {
 func rootSpanFromContext(ctx context.Context) (rootSpan, bool) {
 	s, ok := ctx.Value(rootSpanCtxKey{}).(rootSpan)
 	return s, ok
-}
-
-// WithTraceIDLabel controls whether the "trace_id" pprof label is emitted.
-// Defaults to true.
-func WithTraceIDLabel(enabled bool) Option {
-	return func(tp *tracerProvider) {
-		tp.config.traceIDEnabled = enabled
-	}
 }
 
 // WithSpanNameLabelScope specifies whether the current span name should be

--- a/otelpyroscope_test.go
+++ b/otelpyroscope_test.go
@@ -106,27 +106,6 @@ func Test_traceIDLabel_defaultEnabled(t *testing.T) {
 	root.End()
 }
 
-func Test_traceIDLabel_disabled(t *testing.T) {
-	tracer := NewTracerProvider(
-		trace.NewTracerProvider(),
-		WithTraceIDLabel(false),
-	).Tracer("")
-
-	ctx, span := tracer.Start(context.Background(), "Root")
-	defer span.End()
-
-	labels := collectLabels(ctx)
-	if v, ok := labels[traceIDLabelName]; ok {
-		t.Fatalf("trace_id should be absent, got %q", v)
-	}
-	if _, ok := labels[spanIDLabelName]; !ok {
-		t.Fatal("span_id should still be present")
-	}
-	if _, ok := labels[spanNameLabelName]; !ok {
-		t.Fatal("span_name should still be present")
-	}
-}
-
 func Test_traceIDLabel_unsampledSpan(t *testing.T) {
 	tp := trace.NewTracerProvider(trace.WithSampler(trace.NeverSample()))
 	tracer := NewTracerProvider(tp).Tracer("")

--- a/otelpyroscope_test.go
+++ b/otelpyroscope_test.go
@@ -9,6 +9,15 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace"
 )
 
+func collectLabels(ctx context.Context) map[string]string {
+	m := make(map[string]string)
+	pprof.ForLabels(ctx, func(key, value string) bool {
+		m[key] = value
+		return true
+	})
+	return m
+}
+
 func Test_tracerProvider(t *testing.T) {
 	otel.SetTracerProvider(NewTracerProvider(trace.NewTracerProvider()))
 
@@ -66,4 +75,134 @@ func Test_tracerProvider(t *testing.T) {
 		return true
 	})
 	spanC.End()
+}
+
+func Test_traceIDLabel_defaultEnabled(t *testing.T) {
+	tracer := NewTracerProvider(trace.NewTracerProvider()).Tracer("")
+
+	ctx, root := tracer.Start(context.Background(), "Root")
+	rootLabels := collectLabels(ctx)
+
+	want := root.SpanContext().TraceID().String()
+	if got := rootLabels[traceIDLabelName]; got != want {
+		t.Fatalf("root trace_id = %q, want %q", got, want)
+	}
+	if len(want) != 32 {
+		t.Fatalf("expected 32-char hex trace ID, got %q", want)
+	}
+
+	childCtx, child := tracer.Start(ctx, "Child")
+	if got := collectLabels(childCtx)[traceIDLabelName]; got != want {
+		t.Fatalf("child trace_id = %q, want %q (inherited)", got, want)
+	}
+
+	grandchildCtx, grandchild := tracer.Start(childCtx, "Grandchild")
+	if got := collectLabels(grandchildCtx)[traceIDLabelName]; got != want {
+		t.Fatalf("grandchild trace_id = %q, want %q", got, want)
+	}
+
+	grandchild.End()
+	child.End()
+	root.End()
+}
+
+func Test_traceIDLabel_disabled(t *testing.T) {
+	tracer := NewTracerProvider(
+		trace.NewTracerProvider(),
+		WithTraceIDLabel(false),
+	).Tracer("")
+
+	ctx, span := tracer.Start(context.Background(), "Root")
+	defer span.End()
+
+	labels := collectLabels(ctx)
+	if v, ok := labels[traceIDLabelName]; ok {
+		t.Fatalf("trace_id should be absent, got %q", v)
+	}
+	if _, ok := labels[spanIDLabelName]; !ok {
+		t.Fatal("span_id should still be present")
+	}
+	if _, ok := labels[spanNameLabelName]; !ok {
+		t.Fatal("span_name should still be present")
+	}
+}
+
+func Test_traceIDLabel_unsampledSpan(t *testing.T) {
+	tp := trace.NewTracerProvider(trace.WithSampler(trace.NeverSample()))
+	tracer := NewTracerProvider(tp).Tracer("")
+
+	ctx, span := tracer.Start(context.Background(), "Root")
+	defer span.End()
+
+	if span.SpanContext().IsSampled() {
+		t.Fatal("expected unsampled span")
+	}
+	labels := collectLabels(ctx)
+	if v, ok := labels[traceIDLabelName]; ok {
+		t.Fatalf("trace_id should be absent on unsampled span, got %q", v)
+	}
+	if v, ok := labels[spanIDLabelName]; ok {
+		t.Fatalf("span_id should be absent on unsampled span, got %q", v)
+	}
+}
+
+func Test_traceIDLabel_inheritsAcrossScopeAllSpans(t *testing.T) {
+	// trace_id must stay consistent across spans even when span_id uses
+	// ScopeAllSpans (each span emits its own span_id).
+	tracer := NewTracerProvider(
+		trace.NewTracerProvider(),
+		WithSpanIDLabelScope(ScopeAllSpans),
+	).Tracer("")
+
+	ctx, root := tracer.Start(context.Background(), "Root")
+	defer root.End()
+	want := root.SpanContext().TraceID().String()
+	rootSpanID := root.SpanContext().SpanID().String()
+
+	if got := collectLabels(ctx)[traceIDLabelName]; got != want {
+		t.Fatalf("root trace_id = %q, want %q", got, want)
+	}
+	if got := collectLabels(ctx)[spanIDLabelName]; got != rootSpanID {
+		t.Fatalf("root span_id = %q, want %q", got, rootSpanID)
+	}
+
+	childCtx, child := tracer.Start(ctx, "Child")
+	defer child.End()
+	childSpanID := child.SpanContext().SpanID().String()
+	childLabels := collectLabels(childCtx)
+
+	if got := childLabels[traceIDLabelName]; got != want {
+		t.Fatalf("child trace_id = %q, want %q (constant across trace)", got, want)
+	}
+	if got := childLabels[spanIDLabelName]; got != childSpanID {
+		t.Fatalf("child span_id = %q, want child's own %q under ScopeAllSpans", got, childSpanID)
+	}
+}
+
+// Regression: WithSpanIDLabelScope used to write to spanNameScope.
+func Test_WithSpanIDLabelScope_typoRegression(t *testing.T) {
+	tracer := NewTracerProvider(
+		trace.NewTracerProvider(),
+		WithSpanIDLabelScope(ScopeAllSpans),
+		WithSpanNameLabelScope(ScopeRootSpan),
+	).Tracer("")
+
+	ctx, root := tracer.Start(context.Background(), "Root")
+	defer root.End()
+	rootSpanID := root.SpanContext().SpanID().String()
+
+	childCtx, child := tracer.Start(ctx, "Child")
+	defer child.End()
+	childSpanID := child.SpanContext().SpanID().String()
+	if rootSpanID == childSpanID {
+		t.Fatal("test setup: root and child span IDs should differ")
+	}
+
+	childLabels := collectLabels(childCtx)
+	if got := childLabels[spanIDLabelName]; got != childSpanID {
+		t.Fatalf("child span_id = %q, want %q", got, childSpanID)
+	}
+	if got := childLabels[spanNameLabelName]; got != "Root" {
+		t.Fatalf("child span_name = %q, want %q", got, "Root")
+	}
 }


### PR DESCRIPTION
## Summary

Adds a `trace_id` pprof label that points to the trace a sampled span belongs to. Emitted once on the local root span and inherited by every descendant via pprof's context label propagation, so each CPU sample carries the trace ID it was taken under. Enables filtering profile samples by trace ID server side.

Existing behavior is preserved. `span_id`, `span_name`, and the `pyroscope.profile.id` span attribute keep their previous defaults and continue to back Grafana's "Traces to profiles" UI. Callers can opt out via `WithTraceIDLabel(false)`.

## Notes

* Promoted the previously unexported scope options to public (`WithSpanIDLabelScope`, `WithSpanNameLabelScope`, `Scope` type), finishing the existing TODO next to them. Fixed a typo where `withSpanIDScope` was writing to `spanNameScope`.
* Verified end to end against the `pyroscope/examples/tracing/golang-push` rideshare stack: 92 distinct trace IDs landed in Pyroscope, queryable via `{service_name="ride-sharing-app", trace_id="..."}`.